### PR TITLE
Add GitHub Action to publish Quarto project to GitHub Pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Render Quarto project
+        run: quarto render
+
+      - name: Publish to gh-pages
+        uses: quarto-dev/quarto-actions/publish@v2
+        with:
+          target-branch: gh-pages


### PR DESCRIPTION
This commit adds a GitHub Actions workflow that automatically builds and publishes the Quarto project to the `gh-pages` branch whenever changes are pushed to the `master` branch.

The workflow uses the official Quarto actions to set up Quarto, render the project, and publish the output.